### PR TITLE
Exclude user and logout crash prevention

### DIFF
--- a/back/helpers.js
+++ b/back/helpers.js
@@ -114,12 +114,15 @@ async function updateLanguages(key, data) {
   });
 }
 
-async function getusers() {
+async function getusers(excludeID) {
   let result = [];
   const querySnapshot = await getDocs(collection(db, "Users"));
   querySnapshot.forEach((doc) => {
     let obj = {};
     let user = doc.data();
+    if (excludeID === doc.id) {
+      return;
+    }
     //console.log(doc.id);
     obj.uid = doc.id;
     obj.username = user.username;

--- a/back/server/index.js
+++ b/back/server/index.js
@@ -80,7 +80,7 @@ app.get('/users', async (req, res) => {
   },
   ]
   */
-  const result = await firefunctions.getusers();
+  const result = await firefunctions.getusers(req.query.uid);
   res.status(200).send(result);
 })
 

--- a/client/components/context/AppProvider.js
+++ b/client/components/context/AppProvider.js
@@ -15,6 +15,9 @@ function AppProvider({ children }) {
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, result => {
       console.log('onauth', result);
+      if (result === null) {
+        setUser({});
+      }
       setUser(result);
       //setLoading(false)
     })


### PR DESCRIPTION
When logging out, the user context is set to null.  Reading properties of null results in a crash so we will set the user to an empty object when the user signs out to prevent crashing.  Also excluding user in '/users' get request based on uid.